### PR TITLE
Update /GET Incidents

### DIFF
--- a/rest_server.mjs
+++ b/rest_server.mjs
@@ -144,6 +144,17 @@ app.get('/incidents', (req, res) => {
         count++;
     }
 
+    if(req.query.hasOwnProperty('code')){
+        let codes = req.query.code.split(',');
+        sql += count == 0 ? ' WHERE code = ?': ' OR code = ?';
+        params.push(parseInt(codes[0]));
+        for(let i=1; i<codes.length; i++){
+            sql += ' OR code = ?';
+            params.push(parseInt(codes[i]));
+        }
+        count++;
+    }
+
     if(req.query.hasOwnProperty('limit')){
         limit = parseInt(req.query.limit);
     }

--- a/rest_server.mjs
+++ b/rest_server.mjs
@@ -135,35 +135,38 @@ app.get('/incidents', (req, res) => {
 
     if(req.query.hasOwnProperty('neighborhood')){
         let neighborhoods = req.query.neighborhood.split(',');
-        sql += count == 0 ? ' WHERE neighborhood_number = ?': ' AND neighborhood_number = ?';
+        sql += count == 0 ? ' WHERE (neighborhood_number = ?': ' AND (neighborhood_number = ?';
         params.push(parseInt(neighborhoods[0]));
         for(let i=1; i<neighborhoods.length; i++){
             sql += ' OR neighborhood_number = ?';
             params.push(parseInt(neighborhoods[i]));
         }
+        sql += ')'
         count++;
     }
 
     if(req.query.hasOwnProperty('code')){
         let codes = req.query.code.split(',');
-        sql += count == 0 ? ' WHERE code = ?': ' AND code = ?';
+        sql += count == 0 ? ' WHERE (code = ?': ' AND (code = ?';
         params.push(parseInt(codes[0]));
         for(let i=1; i<codes.length; i++){
             sql += ' OR code = ?';
             params.push(parseInt(codes[i]));
         }
         count++;
+        sql += ')'
     }
 
     if(req.query.hasOwnProperty('grid')){
         let grids = req.query.grid.split(',');
-        sql += count == 0 ? ' WHERE police_grid = ?': ' AND police_grid = ?';
+        sql += count == 0 ? ' WHERE (police_grid = ?': ' AND (police_grid = ?';
         params.push(parseInt(grids[0]));
         for(let i=1; i<grids.length; i++){
             sql += ' OR police_grid = ?';
             params.push(parseInt(grids[i]));
         }
         count++;
+        sql += ')'
     }
 
     if(req.query.hasOwnProperty('limit')){

--- a/rest_server.mjs
+++ b/rest_server.mjs
@@ -155,6 +155,17 @@ app.get('/incidents', (req, res) => {
         count++;
     }
 
+    if(req.query.hasOwnProperty('grid')){
+        let grids = req.query.grid.split(',');
+        sql += count == 0 ? ' WHERE police_grid = ?': ' OR police_grid = ?';
+        params.push(parseInt(grids[0]));
+        for(let i=1; i<grids.length; i++){
+            sql += ' OR police_grid = ?';
+            params.push(parseInt(grids[i]));
+        }
+        count++;
+    }
+
     if(req.query.hasOwnProperty('limit')){
         limit = parseInt(req.query.limit);
     }

--- a/rest_server.mjs
+++ b/rest_server.mjs
@@ -135,7 +135,7 @@ app.get('/incidents', (req, res) => {
 
     if(req.query.hasOwnProperty('neighborhood')){
         let neighborhoods = req.query.neighborhood.split(',');
-        sql += count == 0 ? ' WHERE neighborhood_number = ?': ' OR neighborhood_number = ?';
+        sql += count == 0 ? ' WHERE neighborhood_number = ?': ' AND neighborhood_number = ?';
         params.push(parseInt(neighborhoods[0]));
         for(let i=1; i<neighborhoods.length; i++){
             sql += ' OR neighborhood_number = ?';
@@ -146,7 +146,7 @@ app.get('/incidents', (req, res) => {
 
     if(req.query.hasOwnProperty('code')){
         let codes = req.query.code.split(',');
-        sql += count == 0 ? ' WHERE code = ?': ' OR code = ?';
+        sql += count == 0 ? ' WHERE code = ?': ' AND code = ?';
         params.push(parseInt(codes[0]));
         for(let i=1; i<codes.length; i++){
             sql += ' OR code = ?';
@@ -157,7 +157,7 @@ app.get('/incidents', (req, res) => {
 
     if(req.query.hasOwnProperty('grid')){
         let grids = req.query.grid.split(',');
-        sql += count == 0 ? ' WHERE police_grid = ?': ' OR police_grid = ?';
+        sql += count == 0 ? ' WHERE police_grid = ?': ' AND police_grid = ?';
         params.push(parseInt(grids[0]));
         for(let i=1; i<grids.length; i++){
             sql += ' OR police_grid = ?';

--- a/rest_server.mjs
+++ b/rest_server.mjs
@@ -117,53 +117,39 @@ app.get('/neighborhoods', (req, res) => {
 // GET request handler for crime incidents
 app.get('/incidents', (req, res) => {
     console.log(req.query); // query object (key-value pairs after the ? in the url)
-    let count = 0
     let sql = 'SELECT * FROM Incidents';
-    let whereCount = 0;
-    let colCount = 0;
-    let col = '';
-    let where = '';
-    let limit = 1000;
     let params = [];
+    let limit = 1000;
+    let count = 0;
     if(req.query.hasOwnProperty('start_date')){
-        where += whereCount == 0 ? ' WHERE date_time >= ?':' and date_time >= ?'
-        col += colCount == 0 ? ' date(date_time) as date':', date(date_time) as date';
+        sql += count == 0 ? ' WHERE date_time >= ?': ' AND date_time >= ?'
         params.push(req.query.start_date);
-        whereCount++;
-        colCount++;
+        count++;
     }
 
     if(req.query.hasOwnProperty('end_date')){
-        where += whereCount == 0 ? ' WHERE date_time <= ?':' and date_time <= ?'
-        col += colCount == 0 ? 'time(date_time) as time':', time(date_time) as time';
+        sql += count == 0 ? ' WHERE date_time <= ?': ' AND date_time <= ?'
         params.push(req.query.end_date);
-        whereCount++;
-        colCount++;
+        count++;
     }
 
-    //default: all neighborhood_number
     if(req.query.hasOwnProperty('neighborhood')){
         let neighborhoods = req.query.neighborhood.split(',');
-        where += whereCount == 0 ? ' WHERE neighborhood_number = ?':' and neighborhood_number = ?'
-        col += colCount == 0 ? 'neighborhood_number':', neighborhood_number';
+        sql += count == 0 ? ' WHERE neighborhood_number = ?': ' OR neighborhood_number = ?';
         params.push(parseInt(neighborhoods[0]));
         for(let i=1; i<neighborhoods.length; i++){
-            where += ' OR neighborhood_number = ?';
+            sql += ' OR neighborhood_number = ?';
             params.push(parseInt(neighborhoods[i]));
         }
-    }else{ //neighborhood_number: DEFAULT
-        col += colCount == 0 ? ' neighborhood_number':', neighborhood_number';
+        count++;
     }
-    //moved outside of 'neighborhood' because both cases will inc
-    whereCount++;
-    colCount++;
 
     if(req.query.hasOwnProperty('limit')){
         limit = parseInt(req.query.limit);
     }
     params.push(limit);
-    col = col=='' ? ' * ' : col;
-    //let sql = 'SELECT'+col+' FROM Incidents'+where+' limit ?';
+    sql += ' LIMIT ?';
+    
     console.log(sql);
     console.log('PARAM: ', params);
     

--- a/rest_server.mjs
+++ b/rest_server.mjs
@@ -117,6 +117,8 @@ app.get('/neighborhoods', (req, res) => {
 // GET request handler for crime incidents
 app.get('/incidents', (req, res) => {
     console.log(req.query); // query object (key-value pairs after the ? in the url)
+    let count = 0
+    let sql = 'SELECT * FROM Incidents';
     let whereCount = 0;
     let colCount = 0;
     let col = '';
@@ -161,7 +163,7 @@ app.get('/incidents', (req, res) => {
     }
     params.push(limit);
     col = col=='' ? ' * ' : col;
-    let sql = 'SELECT'+col+' FROM Incidents'+where+' limit ?';
+    //let sql = 'SELECT'+col+' FROM Incidents'+where+' limit ?';
     console.log(sql);
     console.log('PARAM: ', params);
     

--- a/rest_server.mjs
+++ b/rest_server.mjs
@@ -148,8 +148,8 @@ app.get('/incidents', (req, res) => {
         limit = parseInt(req.query.limit);
     }
     params.push(limit);
-    sql += ' LIMIT ?';
-    
+    sql += ' ORDER BY date_time ASC LIMIT ?';
+
     console.log(sql);
     console.log('PARAM: ', params);
     

--- a/rest_server.mjs
+++ b/rest_server.mjs
@@ -117,7 +117,7 @@ app.get('/neighborhoods', (req, res) => {
 // GET request handler for crime incidents
 app.get('/incidents', (req, res) => {
     console.log(req.query); // query object (key-value pairs after the ? in the url)
-    let sql = 'SELECT * FROM Incidents';
+    let sql = 'SELECT case_number, date(date_time) AS date, time(date_time) AS time, code, incident, police_grid, neighborhood_number, block FROM Incidents';
     let params = [];
     let limit = 1000;
     let count = 0;


### PR DESCRIPTION
# Return Object Updates
All incident data fields are now returned when a query parameter is passed. 

For `neighborhood=65`:

*Before*
``` json
{"police_grid": "65"}
```
*After*
``` json
{
      "case_number": "14173172"
      "date": "2014-08-16"
      "time": "06:00:00"
      "code": "1430"
      "incident": "Vandalism"
      "police_grid": "65"
      "neighborhood_number": "11"
      "block": "87X PASCAL ST N"
}
``` 
# Query Parameter Updates
Support for the following parameters has been add:
- `grid`, returns incident data specific to a police grid(s) where an incident occurred. Incident data from all grids are returned by default.
- `code`, returns incident data specific to the incident type(s). Incident data for all incident types are returned by default.

# Incident Ordering
Incident data is now ordered by date when returned from the API. The query parameters `start_date` and `end_date` work in conjunction with this.

# Date & Time Fields
`Date` and `Time` are now returned in two separate fields, as opposed to a single `date_time` field.